### PR TITLE
docs: ajout lien https://git-scm.com/book/fr/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ N'importe quel commit effectué sera poussé depuis Gitlab vers Github.
 
  - [L'art de faire des commits atomiques](http://adopteungit.fr/methodologie/2017/04/26/commits-atomiques-la-bonne-approche.html)
  - [L'art de faire des issues efficaces](https://www.lesintegristes.net/2011/10/19/rediger-un-rapport-de-bugs-ca-na-pas-lair-pas-mais-cest-du-boulot/)
+ - [Documentation "Pro Git" en fr](https://git-scm.com/book/fr/v2)
 
 ## Glossaire
  - **intégration continue** : pratique qui consiste à vérifier chaque modification du code source pour prévenir les régressions.  Le principal but de cette pratique est de détecter les problèmes d'intégration au plus tôt lors du développement. De plus, elle permet d'automatiser l'exécution des suites de tests et de voir l'évolution du développement du logiciel.


### PR DESCRIPTION
Proposition de rajouter le lien vers https://git-scm.com/book/fr/v2